### PR TITLE
Bump jsonschema version to a more recent (and correct) version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema==0.8.0
+jsonschema==2.3.0


### PR DESCRIPTION
The version of jsonschema that this project depends on does not properly validate longs as numbers.  The new version looks at numbers.Number, which is a much better solution.  The tests pass for me.

It would also be swell if you could update the pypi version. :)
