### PR TITLE
install fails with latest distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://pypi.python.org/pypi/json_schema_generator/',
 
     scripts=['bin/jsonschema_generator.py'],
-    include_dirs=('json_schema_generator/',),
+    include_dirs=['json_schema_generator/',],
     packages=['json_schema_generator'],
     #package_data={'jsonschema_generator': ['test_template.py.tmpl']},
     include_package_data=True,


### PR DESCRIPTION
when setup.py's "include_dirs" option is set to a tuple, distutils will fail like:

File "/nix/store/ss1aq46xwhnqikq5bjs02sb9xrim2bb3-python-2.7.10/lib/python2.7/distutils/command/build_ext.py", line 159, in finalize_options
        self.include_dirs.append(py_include)
    AttributeError: 'tuple' object has no attribute 'append'

Simply changing the value to a list does the trick.
