### PR TITLE
bin: fix a python3 syntax error and clarify an argparse exception

### DIFF
--- a/bin/jsonschema_generator.py
+++ b/bin/jsonschema_generator.py
@@ -23,10 +23,10 @@ def validate(args):
     is_valid = validator.assert_json(json_data)
 
     if is_valid:
-        print " * JSON is valid"
+        print (" * JSON is valid")
     else:
-        print " ! JSON is broken "
-        print validator.error_message
+        print (" ! JSON is broken ")
+        print (validator.error_message)
 
 
 def homologate(args):
@@ -79,8 +79,14 @@ def main():
     parser_homologate.set_defaults(func=homologate)
 
     args = parser.parse_args()
-    args.func(args)
-
+    try:
+        args.func
+    except AttributeError:
+        import sys
+        print("missing 1 or more required arguments (see '%s --help')" % sys.argv[0])
+        exit(1)
+    else:
+        args.func(args)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- previously bin/jsonschema_generator.py would not function under
python3 because missing parentheses around print() arguments

- when running 'python3 bin/jsonschema_generator.py', an AttributeError
exception would be thrown with no helpful explanation ("Namespace object
has no attribute 'func'") so a clause is added to catch it
	- note that in Python 2, if the first positional argument was
ommitted, argparse would print an explanation in english -- this was
changed to just throw an AttributeError with vague explanation in Python 3:

```
Traceback (most recent call last):
  File "bin/jsonschema_generator.py", line 87, in <module>
    main()
  File "bin/jsonschema_generator.py", line 83, in main
    args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
```

Huh?