### PR TITLE
Fix urllib import for python3

### DIFF
--- a/bin/jsonschema_generator.py
+++ b/bin/jsonschema_generator.py
@@ -19,7 +19,7 @@ def record(args):
 
 
 def validate(args):
-    from urllib2 import urlopen
+    from six.moves.urllib.request import urlopen
 
     json_data = urlopen(args.json_source).read()
     validator = Validator.from_path(args.json_schema_file_path)

--- a/json_schema_generator/test_template.py.tmpl
+++ b/json_schema_generator/test_template.py.tmpl
@@ -4,7 +4,7 @@ import os
 
 from unittest import TestCase
 from json_schema_generator import Validator
-from urllib2 import urlopen
+from six.moves.urllib.request import urlopen
 
 SERVICE_URL = "${service_url}"
 


### PR DESCRIPTION
Hi,

thanks for the very useful library!
I found an import that only works for python2 and upgraded it to the corresponding six.moves import.
That should take care of it.